### PR TITLE
🍒[6.0] Guard parse_version

### DIFF
--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -144,10 +144,14 @@ config.substitutions.append(('%{xctest_checker}', '%%{python} %s' % xctest_check
 config.substitutions.append( ('%{python}', pipes.quote(sys.executable)) )
 
 # Conditionally report the Swift 5.5 Concurrency runtime as available depending on the OS and version.
+# Darwin is the only platform where this is a limitation.
 (run_os, run_vers) = config.os_info
-os_is_not_macOS = run_os != 'Darwin'
-macOS_version_is_recent_enough = parse_version(run_vers) >= parse_version('12.0')
-if os_is_not_macOS or macOS_version_is_recent_enough:
+if run_os == 'Darwin':
+    assert run_vers != "", "No runtime version set."
+    if parse_version(run_vers) >= parse_version('12.0'):
+        config.available_features.add('concurrency_runtime')
+else:
+    # Non-Darwin platforms have a concurrency runtime
     config.available_features.add('concurrency_runtime')
 if run_os == 'Windows':
     config.available_features.add('OS=windows')


### PR DESCRIPTION
6.0 Cherry-Pick of: https://github.com/apple/swift-corelibs-xctest/pull/489

The most recent versions of `parse_version` throw an exception if the version is empty. The version passed in is only set on Darwin (call to `mac_ver()`, so it's causing test failures on newer versions of Linux since the test suite can't even start.

Now, the only reason for the version parse is because the tests are looking at whether or not concurrency is available on the OS. This is only a limitation if we're working with Darwin. Swift 5.10 on Windows and Linux always have a Swift 5.10 concurrency runtime, so we don't even need to check for a version.

rdar://128502662
(cherry picked from commit 65e6ecdce29101129911c49760b0f85ac18d21e5)