### PR TITLE
Fix incorrect help documentation of XCTestMain

### DIFF
--- a/Sources/XCTest/Public/XCTestMain.swift
+++ b/Sources/XCTest/Public/XCTestMain.swift
@@ -182,7 +182,7 @@ internal func XCTMainMisc(
 
               OPTIONS:
 
-              -l, --list-test              List tests line by line to standard output
+              -l, --list-tests             List tests line by line to standard output
                   --dump-tests-json        List tests in JSON to standard output
 
               TESTCASES:


### PR DESCRIPTION
The option `--list-test` is incorrect. The correct option is [`--list-tests`](https://github.com/apple/swift-corelibs-xctest/blob/7a9df99f405b39be19d74304a76ba9b515ab228c/Sources/XCTest/Private/ArgumentParser.swift#L60).

This is the same as https://github.com/apple/swift-corelibs-foundation/pull/5044.