### PR TITLE
Add `Error` members to `XCTSkip` so it can be bridged to Swift Testing.

### DIFF
--- a/Sources/XCTest/Public/XCTSkip.swift
+++ b/Sources/XCTest/Public/XCTSkip.swift
@@ -60,6 +60,32 @@ public struct XCTSkip: Error {
         self.init(explanation: explanation, message: message, sourceLocation: sourceLocation)
     }
 
+    public var _code: Int {
+        106 // XCTestErrorCodeSkippedTest
+    }
+
+    public var _domain: String {
+        "com.apple.XCTestErrorDomain"
+    }
+
+    public var _userInfo: AnyObject? {
+        var result = [String: Any]()
+
+        result["XCTestErrorUserInfoKeyMessage"] = message
+        result["XCTestErrorUserInfoKeyExplanation"] = explanation
+        result["XCTestErrorUserInfoKeySourceLocation"] = sourceLocation.map { sourceLocation -> [String: Any] in
+            // TODO: plumb fileID/filePath through the library
+            let fileName = URL(fileURLWithPath: sourceLocation.file, isDirectory: false).lastPathComponent
+            return [
+                "fileID": "<unknown>/\(fileName)",
+                "filePath": sourceLocation.file,
+                "line": Int(clamping: max(1, sourceLocation.line)),
+                "column": 1,
+            ]
+        }
+
+        return result as AnyObject
+    }
 }
 
 extension XCTSkip: XCTCustomErrorHandling {


### PR DESCRIPTION
This PR adds the aforementioned members (`_code`, `_domain`, and `_userInfo`) to `XCTSkip` so Swift Testing can bridge it to its own test cancellation/skipping logic.

The values selected for the code and domain match what `XCTSkip` reports on Apple platforms. The user info dictionary keys are arbitrary.