### PR TITLE
test: quote path to swiftc executable

### DIFF
--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -41,7 +41,7 @@ def _getenv(name):
 
 built_products_dir = _getenv('BUILT_PRODUCTS_DIR')
 # Force tests to build with -swift-version 5 for now.
-swift_exec = [ _getenv('SWIFT_EXEC'), '-swift-version', '5', ]
+swift_exec = [ '"' + _getenv('SWIFT_EXEC') + '"', '-swift-version', '5', ]
 swift_exec.extend(shlex.split(os.getenv('SWIFT_FLAGS', '')))
 if not platform.system() == 'Windows':
     swift_exec.extend(['-Xlinker', '-rpath', '-Xlinker', built_products_dir,])


### PR DESCRIPTION
Quote the path to `SWIFT_EXEC` to allow for spaces on Windows.