### PR TITLE
Remove `pipes` module from LIT tests

### DIFF
--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -14,7 +14,6 @@ import tempfile
 import shlex
 import sys
 import lit
-import pipes
 import re
 
 # Set up lit config.
@@ -141,7 +140,7 @@ xctest_checker = os.path.join(
 config.substitutions.append(('%{xctest_checker}', '%%{python} %s' % xctest_checker))
 
 # Add Python to run xctest_checker.py tests as part of XCTest tests
-config.substitutions.append( ('%{python}', pipes.quote(sys.executable)) )
+config.substitutions.append( ('%{python}', shlex.quote(sys.executable)) )
 
 # Conditionally report the Swift 5.5 Concurrency runtime as available depending on the OS and version.
 # Darwin is the only platform where this is a limitation.


### PR DESCRIPTION
The pipes module was removed in Python 3.13.

(cherry picked from commit 35b964cb3923ab9ea7f6fcf93fb42a8891eb414c)