### PR TITLE
Access Testing SPI in CMake built of corelibs XCTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,9 +85,11 @@ find_package(SwiftTesting CONFIG)
 find_package(SwiftTestingMacros CONFIG)
 if(SwiftTesting_FOUND)
   target_link_libraries(XCTest PRIVATE
-    _TestingInterop)
+    _TestingInterop
+    Testing)
   target_compile_definitions(XCTest PRIVATE
-    XCT_BUILD_WITH_INTEROP)
+    XCT_BUILD_WITH_INTEROP
+    XCT_CAN_USE_TESTING_SPI)
 endif()
 
 if(USE_FOUNDATION_FRAMEWORK)

--- a/Sources/XCTest/Private/Interop/InteropHandler.swift
+++ b/Sources/XCTest/Private/Interop/InteropHandler.swift
@@ -101,11 +101,8 @@ extension Interop.Handler {
         // When building for the toolchain, support ABI versions 6.3 to 6.4.
 #if XCT_CAN_USE_TESTING_SPI
         guard
-            let schemaVersionNumber = String(
-                validatingCString: recordJSONSchemaVersionNumber
-            ).flatMap(ABI.VersionNumber.init),
-            (ABI.v6_3.versionNumber...ABI.v6_4.versionNumber).contains(schemaVersionNumber),
-            ABI.version(forVersionNumber: schemaVersionNumber) != nil else {
+            let schemaVersionNumber = ABI.VersionNumber.init(validatingCString: recordJSONSchemaVersionNumber),
+            (ABI.v6_3.versionNumber...ABI.v6_4.versionNumber).contains(schemaVersionNumber) else {
             return
         }
 #else

--- a/Sources/XCTest/Private/Interop/InteropHandler.swift
+++ b/Sources/XCTest/Private/Interop/InteropHandler.swift
@@ -19,6 +19,9 @@
 #else
     import Foundation
 #endif
+#if XCT_CAN_USE_TESTING_SPI
+@_spi(ForToolsIntegrationOnly) private import Testing
+#endif
 
 enum Interop {}
 
@@ -94,10 +97,23 @@ extension Interop.Handler {
     /// It can only report test issues if there is an active XCTest test case.
     static let ourFallbackEventHandler: FallbackEventHandler = {
         recordJSONSchemaVersionNumber, recordJSONBaseAddress, recordJSONByteCount, _ in
+        // Check that this schema version number is supported.
+        // When building for the toolchain, support ABI versions 6.3 to 6.4.
+#if XCT_CAN_USE_TESTING_SPI
+        guard
+            let schemaVersionNumber = String(
+                validatingCString: recordJSONSchemaVersionNumber
+            ).flatMap(ABI.VersionNumber.init),
+            (ABI.v6_3.versionNumber...ABI.v6_4.versionNumber).contains(schemaVersionNumber),
+            ABI.version(forVersionNumber: schemaVersionNumber) != nil else {
+            return
+        }
+#else
         guard let schemaVersion = String(validatingCString: recordJSONSchemaVersionNumber),
                 schemaVersion == "6.3" else {
             return
         }
+#endif
 
         // Memory is managed by the caller of the fallback event handler, so do
         // not attempt to deallocate when done.

--- a/Sources/XCTest/Private/Interop/InteropHandler.swift
+++ b/Sources/XCTest/Private/Interop/InteropHandler.swift
@@ -101,7 +101,7 @@ extension Interop.Handler {
         // When building for the toolchain, support ABI versions 6.3 to 6.4.
 #if XCT_CAN_USE_TESTING_SPI
         guard
-            let schemaVersionNumber = ABI.VersionNumber.init(validatingCString: recordJSONSchemaVersionNumber),
+            let schemaVersionNumber = ABI.VersionNumber(validatingCString: recordJSONSchemaVersionNumber),
             (ABI.v6_3.versionNumber...ABI.v6_4.versionNumber).contains(schemaVersionNumber) else {
             return
         }


### PR DESCRIPTION
Access Testing SPI for interop when performing CMake build

Begin sharing some code between XCTest and Swift Testing in the interop
implementation.

## Motivation

In a follow-up, XCTest will favour using ABI.Record in Testing over the
Interop.OutputRecord, which will lead to lower maintenance following
future record schema changes.

## Modifications

* Decode event version with ABI.version in the fallback handler

  Essentially no functional change, as Swift Testing still always
  encodes the fallback events as version 6.3.

  This is only available when building in CMake against the Swift
  Testing module, e.g. a full toolchain build. Otherwise, continue to
  check event version is exactly version 6.3.

* Define XCT_CAN_USE_TESTING_SPI in CMake

  The Swift Testing module now shares SPI following
  https://github.com/swiftlang/swift-testing/pull/1755