### PR TITLE
[rebranch] Migrate functional lit tests off the removed %T substitution

### DIFF
--- a/Tests/Functional/ArgumentParser/main.swift
+++ b/Tests/Functional/ArgumentParser/main.swift
@@ -1,5 +1,5 @@
-// RUN: %{swiftc} %s -o %T/ArgumentParser
-// RUN: %T/ArgumentParser
+// RUN: %{swiftc} %s -o %t.ArgumentParser
+// RUN: %t.ArgumentParser
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/Asynchronous/Expectations/Cleanup/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/Cleanup/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/ExpectationCleanup
-// RUN: %T/ExpectationCleanup > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -o %t.ExpectationCleanup
+// RUN: %t.ExpectationCleanup > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/Asynchronous
-// RUN: %T/Asynchronous > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -o %t.Asynchronous
+// RUN: %t.Asynchronous > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/Asynchronous/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Handler/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/Handler
-// RUN: %T/Handler > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -o %t.Handler
+// RUN: %t.Handler > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/Asynchronous/Misuse/main.swift
+++ b/Tests/Functional/Asynchronous/Misuse/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/Misuse
-// RUN: %T/Misuse > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -o %t.Misuse
+// RUN: %t.Misuse > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/Asynchronous/NonsendingFulfillment/main.swift
+++ b/Tests/Functional/Asynchronous/NonsendingFulfillment/main.swift
@@ -1,4 +1,4 @@
-// RUN: %{swiftc} %s -o %T/NonsendingFulfillment -warn-concurrency -warnings-as-errors
+// RUN: %{swiftc} %s -o %t.NonsendingFulfillment -warn-concurrency -warnings-as-errors
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/Asynchronous-Notifications
-// RUN: %T/Asynchronous-Notifications > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -o %t.Asynchronous-Notifications
+// RUN: %t.Asynchronous-Notifications > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/Asynchronous/Notifications/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Notifications/Handler/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/Asynchronous-Notifications-Handler
-// RUN: %T/Asynchronous-Notifications-Handler > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -o %t.Asynchronous-Notifications-Handler
+// RUN: %t.Asynchronous-Notifications-Handler > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/Asynchronous/Predicates/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Predicates/Expectations/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/Asynchronous-Predicates
-// RUN: %T/Asynchronous-Predicates > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -o %t.Asynchronous-Predicates
+// RUN: %t.Asynchronous-Predicates > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/Asynchronous/Predicates/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Predicates/Handler/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/Asynchronous-Predicates-Handler
-// RUN: %T/Asynchronous-Predicates-Handler > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -o %t.Asynchronous-Predicates-Handler
+// RUN: %t.Asynchronous-Predicates-Handler > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/Asynchronous/Use/main.swift
+++ b/Tests/Functional/Asynchronous/Use/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/Use
-// RUN: %T/Use > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -o %t.Use
+// RUN: %t.Use > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 // REQUIRES: concurrency_runtime
 
 #if os(macOS)

--- a/Tests/Functional/DetachedTaskLostFailure/main.swift
+++ b/Tests/Functional/DetachedTaskLostFailure/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/DetachedTaskLostFailure
-// RUN: %T/DetachedTaskLostFailure > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -o %t.DetachedTaskLostFailure
+// RUN: %t.DetachedTaskLostFailure > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/EqualityWithAccuracy/main.swift
+++ b/Tests/Functional/EqualityWithAccuracy/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/EqualityWithAccuracy
-// RUN: %T/EqualityWithAccuracy > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -o %t.EqualityWithAccuracy
+// RUN: %t.EqualityWithAccuracy > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/ErrorHandling
-// RUN: %T/ErrorHandling > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -o %t.ErrorHandling
+// RUN: %t.ErrorHandling > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/FailingTestSuite/main.swift
+++ b/Tests/Functional/FailingTestSuite/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/FailingTestSuite
-// RUN: %T/FailingTestSuite > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -o %t.FailingTestSuite
+// RUN: %t.FailingTestSuite > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/FailureMessagesTestCase/main.swift
+++ b/Tests/Functional/FailureMessagesTestCase/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/FailureMessagesTestCase
-// RUN: %T/FailureMessagesTestCase > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -o %t.FailureMessagesTestCase
+// RUN: %t.FailureMessagesTestCase > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/InteropModeNone/main.swift
+++ b/Tests/Functional/InteropModeNone/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/InteropModeNone
-// RUN: env SWIFT_TESTING_XCTEST_INTEROP_MODE=none %T/InteropModeNone > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -o %t.InteropModeNone
+// RUN: env SWIFT_TESTING_XCTEST_INTEROP_MODE=none %t.InteropModeNone > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/InteropSWTInXCTest/main.swift
+++ b/Tests/Functional/InteropSWTInXCTest/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/InteropSWTInXCTest
-// RUN: %T/InteropSWTInXCTest > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -o %t.InteropSWTInXCTest
+// RUN: %t.InteropSWTInXCTest > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/InteropXCTestInSWT/main.swift
+++ b/Tests/Functional/InteropXCTestInSWT/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/InteropXCTestInSWT -enable-experimental-feature Extern
-// RUN: %T/InteropXCTestInSWT > %t 2>&1 || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -o %t.InteropXCTestInSWT -enable-experimental-feature Extern
+// RUN: %t.InteropXCTestInSWT > %t.output 2>&1 || true
+// RUN: %{xctest_checker} %t.output %s
 
 // Test that XCTFail called without an active XCTestCase forwards the failure
 // to the installed fallback event handler (the XCTest → Swift Testing direction).

--- a/Tests/Functional/ListTests/main.swift
+++ b/Tests/Functional/ListTests/main.swift
@@ -1,9 +1,9 @@
-// RUN: %{swiftc} %s -o %T/ListTests
-// RUN: %T/ListTests --list-tests > %t_list || true
-// RUN: %{xctest_checker} %t_list %s
-// RUN: %T/ListTests --dump-tests-json > %t_json || true
-// RUN: %T/ListTests --verify %t_json > %t_verify
-// RUN: %{xctest_checker} %t_verify %S/verify_json.expected
+// RUN: %{swiftc} %s -module-name ListTests -o %t.ListTests
+// RUN: %t.ListTests --list-tests > %t.list || true
+// RUN: %{xctest_checker} %t.list %s
+// RUN: %t.ListTests --dump-tests-json > %t.json || true
+// RUN: %t.ListTests --verify %t.json > %t.verify
+// RUN: %{xctest_checker} %t.verify %S/verify_json.expected
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/Observation/All/main.swift
+++ b/Tests/Functional/Observation/All/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/All
-// RUN: %T/All > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -o %t.All
+// RUN: %t.All > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/Observation/MultipleObservers/main.swift
+++ b/Tests/Functional/Observation/MultipleObservers/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/MultipleObservers
-// RUN: %T/MultipleObservers > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -o %t.MultipleObservers
+// RUN: %t.MultipleObservers > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/Observation/Selected/main.swift
+++ b/Tests/Functional/Observation/Selected/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/Selected
-// RUN: %T/Selected Selected.ExecutedTestCase/test_executed > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -module-name Selected -o %t.Selected
+// RUN: %t.Selected Selected.ExecutedTestCase/test_executed > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/Performance/Misuse/main.swift
+++ b/Tests/Functional/Performance/Misuse/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/PerformanceMisuse
-// RUN: %T/PerformanceMisuse > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -o %t.PerformanceMisuse
+// RUN: %t.PerformanceMisuse > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/Performance/main.swift
+++ b/Tests/Functional/Performance/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/Performance
-// RUN: %T/Performance > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -o %t.Performance
+// RUN: %t.Performance > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/SelectedTest/main.swift
+++ b/Tests/Functional/SelectedTest/main.swift
@@ -1,12 +1,12 @@
-// RUN: %{swiftc} %s -o %T/SelectedTest
-// RUN: %T/SelectedTest SelectedTest.ExecutedTestCase/test_foo > %T/one_test_case || true
-// RUN: %T/SelectedTest SelectedTest.ExecutedTestCase > %T/one_test_case_class || true
-// RUN: %T/SelectedTest SelectedTest.ExecutedTestCase/test_foo,SelectedTest.ExecutedTestCase/test_bar > %T/two_test_cases || true
-// RUN: %T/SelectedTest > %T/all || true
-// RUN: %{xctest_checker} -p "// CHECK-METHOD:" %T/one_test_case %s
-// RUN: %{xctest_checker} -p "// CHECK-CLASS:" %T/one_test_case_class %s
-// RUN: %{xctest_checker} -p "// CHECK-TWO-METHODS:" %T/two_test_cases %s
-// RUN: %{xctest_checker} -p "// CHECK-ALL:" %T/all %s
+// RUN: %{swiftc} %s -module-name SelectedTest -o %t.SelectedTest
+// RUN: %t.SelectedTest SelectedTest.ExecutedTestCase/test_foo > %t.one_test_case || true
+// RUN: %t.SelectedTest SelectedTest.ExecutedTestCase > %t.one_test_case_class || true
+// RUN: %t.SelectedTest SelectedTest.ExecutedTestCase/test_foo,SelectedTest.ExecutedTestCase/test_bar > %t.two_test_cases || true
+// RUN: %t.SelectedTest > %t.all || true
+// RUN: %{xctest_checker} -p "// CHECK-METHOD:" %t.one_test_case %s
+// RUN: %{xctest_checker} -p "// CHECK-CLASS:" %t.one_test_case_class %s
+// RUN: %{xctest_checker} -p "// CHECK-TWO-METHODS:" %t.two_test_cases %s
+// RUN: %{xctest_checker} -p "// CHECK-ALL:" %t.all %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/SingleFailingTestCase/main.swift
+++ b/Tests/Functional/SingleFailingTestCase/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/SingleFailingTestCase
-// RUN: %T/SingleFailingTestCase > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -o %t.SingleFailingTestCase
+// RUN: %t.SingleFailingTestCase > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/SkippingTestCase/main.swift
+++ b/Tests/Functional/SkippingTestCase/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/SkippingTestCase
-// RUN: %T/SkippingTestCase > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -o %t.SkippingTestCase
+// RUN: %t.SkippingTestCase > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/TestCaseLifecycle/Misuse/main.swift
+++ b/Tests/Functional/TestCaseLifecycle/Misuse/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -g -o %T/TestCaseLifecycleMisuse
-// RUN: env SWIFT_BACKTRACE=enable=no %T/TestCaseLifecycleMisuse > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -g -o %t.TestCaseLifecycleMisuse
+// RUN: env SWIFT_BACKTRACE=enable=no %t.TestCaseLifecycleMisuse > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/TestCaseLifecycle/main.swift
+++ b/Tests/Functional/TestCaseLifecycle/main.swift
@@ -1,6 +1,6 @@
-// RUN: %{swiftc} %s -o %T/TestCaseLifecycle
-// RUN: %T/TestCaseLifecycle > %t || true
-// RUN: %{xctest_checker} %t %s
+// RUN: %{swiftc} %s -o %t.TestCaseLifecycle
+// RUN: %t.TestCaseLifecycle > %t.output || true
+// RUN: %{xctest_checker} %t.output %s
 
 #if os(macOS)
     import SwiftXCTest

--- a/Tests/Functional/xctest_checker/xctest_checker/main.py
+++ b/Tests/Functional/xctest_checker/xctest_checker/main.py
@@ -32,7 +32,7 @@ def main():
             debugging the test suite. To compare the actual output of an
             executable against the expected output, you may run the following:
 
-                Tests/Functional/MyTestCase/Output/MyTestCase | \\
+                Tests/Functional/MyTestCase/Output/main.swift.tmp.MyTestCase | \\
                     %(prog)s - Tests/Functional/MyTestCase/main.swift
 
             This pipes the output from the "MyTestCase" executable into


### PR DESCRIPTION
### One Line Summary

Migrate the functional lit tests off lit's removed %T substitution

### Motivation

  This is part of the rebranch effort to update Swift and associated projects to compile against LLVM-23.

  Starting with LLVM-23, lit no longer supports %T:

  1. llvm/llvm-project@7ff6973f1ae9 ("[lit] Remove support for %T", PR #160028) dropped the substitution.
  2. llvm/llvm-project@fb2c5b1b2bd6 ("[lit] Remove error message for %T") removed the diagnostic, so %T is now left in the command line verbatim.

  check-xctest runs via ${LLVM_MAIN_SRC_DIR}/utils/lit/lit.py, so every test in the xctest test suite that used %T failed
  with ld.gold: fatal error: %T/<name>: open: No such file or directory — the literal, unsubstituted %T passed as the
  linker output path.
  
### Modifications:

  - Build each test binary at %t.<Name> (lit creates %t's parent directory), keeping the old descriptive name so the
    artifact left behind in Output/ still says what it is.
  - Move the captured output from %t to %t.output, and turn per-run output files that used to live in the %T directory
    (%T/all, …) into %t.<name> siblings. The main Swift test trees already use this idiom.
  - Pass -module-name explicitly in ListTests, Observation/Selected, and SelectedTest. Those three rely on the default
    module name (their expected output / CLI test filters are written as <ModuleName>.TestCase/test); the old %T/<Name>
    output name happened to yield module <Name>, but any %t-based path has the base main.swift.tmp, which is not a valid
    identifier, so the driver silently falls back to module main. The remaining tests do not depend on the module name,
    and the hyphenated ones (Asynchronous-Notifications and friends) were already falling back to main before this change.
  - Update the xctest_checker usage example to reflect the new Output/main.swift.tmp.<Name> binary path.

  %t is already supported on main, so this is safe to land there and unblocks rebranch.

----

This is part of the rebranch effort to update swift and associated projects to update to compile against LLVM-23.

Starting with LLVM-23, lit no longer supports %T:

1. llvm/llvm-project@7ff6973f1ae9 ("[lit] Remove support for %T", PR #160028) dropped the substitution.

2. llvm/llvm-project@fb2c5b1b2bd6 ("[lit] Remove error message for %T", PR so %T is now left in the command line verbatim.

check-xctest runs via ${LLVM_MAIN_SRC_DIR}/utils/lit/lit.py, so every test in the xctest test suite that used %T failed with 'ld.gold: fatal error: %T/<name>: open: No such file or directory' -- the literal, unsubstituted %T passed as the linker output path.

Build each test binary at %t.<Name> (lit creates %t's parent directory), keeping the old, descriptive name so the artifact left behind in Output/ still says what it is; the captured output moves from %t to %t.output, and per-run output files that used to live in the %T directory (%T/all, ...) become %t.<name> siblings. The main Swift test trees already use this idiom.

ListTests, Observation/Selected and SelectedTest additionally rely on the default module name (their expected output / CLI test filters are written as <ModuleName>.TestCase/test). The old %T/<Name> output name happened to yield module <Name>; any %t-based path has the base 'main.swift.tmp', which is not a valid identifier, so the driver silently falls back to module 'main'. Pass -module-name explicitly in those three tests. The remaining tests do not depend on the module name, and the hyphenated ones (Asynchronous-Notifications and friends) were already falling back to 'main' before this change.

%t is already supported on main, so it is safe to land there and unblocks rebranch.
